### PR TITLE
fix: Avoid loading tiles out of bounds

### DIFF
--- a/GameMapStorageWebSite/Scripts/map-utils/GameMapUtils.ts
+++ b/GameMapStorageWebSite/Scripts/map-utils/GameMapUtils.ts
@@ -115,8 +115,10 @@ namespace GameMapUtils {
             zoomAnimation: !mapInfos.isSvg
         }) as MapWithGrid;
 
+        const sizeInMeters = mapInfos.sizeInMeters || (mapInfos.tileSize / mapInfos.factorX);
+
         map.grid = new MapGrid({
-            sizeInMeters: mapInfos.sizeInMeters || (mapInfos.tileSize / mapInfos.factorX),
+            sizeInMeters: sizeInMeters,
             originX: mapInfos.originX || 0,
             originY: mapInfos.originY || 0,
             defaultPrecision: 4
@@ -127,7 +129,7 @@ namespace GameMapUtils {
             tileSize: mapInfos.tileSize,
             maxNativeZoom: mapInfos.maxZoom,
             noWrap: true,
-            bounds: [[0, 0], [mapInfos.sizeInMeters, mapInfos.sizeInMeters]]
+            bounds: [[0, 0], [sizeInMeters, sizeInMeters]]
         }).addTo(map);
 
         if (mapInfos.bounds) {

--- a/GameMapStorageWebSite/wwwroot/js/map-utils.js
+++ b/GameMapStorageWebSite/wwwroot/js/map-utils.js
@@ -531,8 +531,9 @@ var GameMapUtils;
             zoomSnap: 0.25,
             zoomAnimation: !mapInfos.isSvg
         });
+        const sizeInMeters = mapInfos.sizeInMeters || (mapInfos.tileSize / mapInfos.factorX);
         map.grid = new MapGrid({
-            sizeInMeters: mapInfos.sizeInMeters || (mapInfos.tileSize / mapInfos.factorX),
+            sizeInMeters: sizeInMeters,
             originX: mapInfos.originX || 0,
             originY: mapInfos.originY || 0,
             defaultPrecision: 4
@@ -542,7 +543,7 @@ var GameMapUtils;
             tileSize: mapInfos.tileSize,
             maxNativeZoom: mapInfos.maxZoom,
             noWrap: true,
-            bounds: [[0, 0], [mapInfos.sizeInMeters, mapInfos.sizeInMeters]]
+            bounds: [[0, 0], [sizeInMeters, sizeInMeters]]
         }).addTo(map);
         if (mapInfos.bounds) {
             map.fitBounds(mapInfos.bounds);


### PR DESCRIPTION
Avoid loading tiles out of bounds to reduce server error rate